### PR TITLE
Improve cleanup commands

### DIFF
--- a/org.artisan_scope.artisan.yml
+++ b/org.artisan_scope.artisan.yml
@@ -22,12 +22,6 @@ cleanup-commands:
     keep = [basename(f) for f in [YAPI._yApiCLibFile]] # might include YAPI._yApiCLibFileFallback
     [remove(join(dir, f)) for f in listdir(dir) if f not in keep]
     EOF
-  # cleanup QtWebEngine dictionaries, which we don't need and use quite some space
-  - find $FLATPAK_DEST/share/locale -name \*.bdic | xargs rm -f
-  - rm -Rf $FLATPAK_DEST/qtwebengine_dictionaries
-  # we need no QtWebEngine developer tools, nor automation driver
-  - rm -f $FLATPAK_DEST/resources/qtwebengine_devtools_resources.pak
-  - rm -Rf $FLATPAK_DEST/libexec/webenginedriver
   # cleanup base
   - /app/cleanup-BaseApp.sh
 build-options:

--- a/org.artisan_scope.artisan.yml
+++ b/org.artisan_scope.artisan.yml
@@ -30,7 +30,9 @@ cleanup-commands:
   - rm -Rf $FLATPAK_DEST/libexec/webenginedriver
   # cleanup base
   - /app/cleanup-BaseApp.sh
-
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
 command: artisan
 separate-locales: false
 finish-args:


### PR DESCRIPTION
> While it's not required, it's possible to set the environment variable BASEAPP_REMOVE_WEBENGINE to have the BaseApp-cleanup.sh script remove the PyQtWebEngine bindings and QtWebEngine with its dependencies. 

Source: https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp?tab=readme-ov-file#example-pyqt-application

The installed size was reduced from **704 MB** to **459 MB**. 

**Please don't forget to test before merging.**